### PR TITLE
Fix bashrc

### DIFF
--- a/jupyter_tensorboard_proxy/__init__.py
+++ b/jupyter_tensorboard_proxy/__init__.py
@@ -23,10 +23,11 @@ def setup_tensorboard():
         if not executable:
             raise FileNotFoundError('Can not find tensorboard executable in $PATH')
 
-        # NOTE: With the edits below, it will expect to find the TF_LOG_DIR variable
+        # NOTES: With the edits below, it will expect to find the TF_LOG_DIR variable
         #   either already exported in the current shell session, or located in a ~/.tensorboard file
-        # In addition, if using s3 for the location, it will also expect to find these env vars in the same location
+        # In addition, if using s3 for the location, it will also expect to find these env vars in the same location, either as env vars or in ~/.tensorboard
         #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, S3_ENDPOINT_URL (if not official AWS)
+        #   If these vars are not found, errors will result from boto3 within tensorflow-io, so no error handling is needed here.
 
         # first look for --logdir override in the form of an s3 bucket or alternate path, then fall back to home_dir if not found
         if os.environ.get('TF_LOG_DIR'):

--- a/jupyter_tensorboard_proxy/__init__.py
+++ b/jupyter_tensorboard_proxy/__init__.py
@@ -19,15 +19,27 @@ def setup_tensorboard():
 
     # Make sure executable is in $PATH
     def _get_tensorboard_command(port):
+        """
+        Takes in port number and returns a tensorboard command like this:
+            `tensorboard --logdir {TF_LOG_DIR} --port {port}`
+        
+        TF_LOG_DIR and AWS/S3 credentials (if relevant) can be curated either:
+            - as environment variables, or
+            - in a file named ~/.tensorboard
+        
+        If TF_LOG_DIR is not provided, the logdir defaults to the $HOME/logs directory
+        
+        If TF_LOG_DIR is specified as an s3:// bucket, required variables in environment
+        or ~/.tensorboard include:
+        
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+            - S3_ENDPOINT_URL (if not official AWS)
+        """
         executable = shutil.which('tensorboard')
         if not executable:
             raise FileNotFoundError('Can not find tensorboard executable in $PATH')
-
-        # NOTES: With the edits below, it will expect to find the TF_LOG_DIR variable
-        #   either already exported in the current shell session, or located in a ~/.tensorboard file
-        # In addition, if using s3 for the location, it will also expect to find these env vars in the same location, either as env vars or in ~/.tensorboard
-        #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, S3_ENDPOINT_URL (if not official AWS)
-        #   If these vars are not found, errors will result from boto3 within tensorflow-io, so no error handling is needed here.
 
         # first look for --logdir override in the form of an s3 bucket or alternate path, then fall back to home_dir if not found
         if os.environ.get('TF_LOG_DIR'):

--- a/jupyter_tensorboard_proxy/__init__.py
+++ b/jupyter_tensorboard_proxy/__init__.py
@@ -22,7 +22,7 @@ def setup_tensorboard():
         if not executable:
             raise FileNotFoundError('Can not find tensorboard executable in $PATH')
         # Create theia working directory
-        home_dir = os.environ.get('HOME') or '/home/jovyan'
+        home_dir = os.environ.get('HOME') or "/home/%s" % os.environ.get('NB_USER') or '/home/jovyan'
         working_dir = f'{home_dir}'
         if not os.path.exists(working_dir):
             os.makedirs(working_dir)

--- a/jupyter_tensorboard_proxy/__init__.py
+++ b/jupyter_tensorboard_proxy/__init__.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+from dotenv import load_dotenv
 
 
 logger = logging.getLogger(__name__)
@@ -21,15 +22,33 @@ def setup_tensorboard():
         executable = shutil.which('tensorboard')
         if not executable:
             raise FileNotFoundError('Can not find tensorboard executable in $PATH')
-        # Create theia working directory
-        home_dir = os.environ.get('HOME') or "/home/%s" % os.environ.get('NB_USER') or '/home/jovyan'
-        working_dir = f'{home_dir}'
-        if not os.path.exists(working_dir):
-            os.makedirs(working_dir)
-            logger.info("Created directory %s" % working_dir)
-        else:    
-            logger.info("Directory %s already exists" % working_dir)
-        return ['tensorboard', '--logdir', '%s/logs' % home_dir, '--port', '{port}']
+
+        # NOTE: With the edits below, it will expect to find the TF_LOG_DIR variable
+        #   either already exported in the current shell session, or located in a ~/.tensorboard file
+        # In addition, if using s3 for the location, it will also expect to find these env vars in the same location
+        #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, S3_ENDPOINT_URL (if not official AWS)
+
+        # first look for --logdir override in the form of an s3 bucket or alternate path, then fall back to home_dir if not found
+        if os.environ.get('TF_LOG_DIR'):
+            TF_LOG_DIR = os.environ.get('TF_LOG_DIR')
+        # providing a second option to store this in a dot file, as env vars are context/session specific
+        elif os.path.isfile("%s/.tensorboard" % os.environ.get('HOME')):
+            load_dotenv("%s/.tensorboard" % os.environ.get('HOME'))
+            if not os.environ.get('TF_LOG_DIR'):
+                logger.error("If you wish to change the tensorflow/tensorboard TF_LOG_DIR via config file instead of env var, you must put 'TF_LOG_DIR=path' in the $HOME/.tensorboard file")
+            else:
+                TF_LOG_DIR = os.environ.get('TF_LOG_DIR')
+        else:
+            # Create working directory
+            home_dir = os.environ.get('HOME') or "/home/%s" % os.environ.get('NB_USER') or '/home/jovyan'
+            working_dir = f'{home_dir}'
+            if not os.path.exists(working_dir):
+                os.makedirs(working_dir)
+                logger.info("Created directory %s" % working_dir)
+            else:
+                logger.info("Directory %s already exists" % working_dir)
+            TF_LOG_DIR = '%s/logs' % home_dir
+        return ['tensorboard', '--logdir', TF_LOG_DIR, '--port', '{port}']
     
     return {
         'command': _get_tensorboard_command,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name="jupyter-tensorboard-proxy",
-    version='0.2.0',
+    version='0.2.1',
     url="https://github.com/kopwei/jupyter-tensorboard-proxy",
     author="kopkop",
     description="kopkop@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setuptools.setup(
 	classifiers=['Framework :: Jupyter'],
     install_requires=[
         'jupyter-server-proxy>=1.5.0',
-        'tensorboard>=2.4.1'
+        'tensorboard>=2.4.1',
+        'tensorflow-io>=0.32.0'
     ],
     entry_points={
         'jupyter_serverproxy_servers': [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name="jupyter-tensorboard-proxy",
-    version='0.1.1',
+    version='0.2.0',
     url="https://github.com/kopwei/jupyter-tensorboard-proxy",
     author="kopkop",
     description="kopkop@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
 	classifiers=['Framework :: Jupyter'],
     install_requires=[
         'jupyter-server-proxy>=1.5.0',
+        'python-dotenv>=1.0.0',
         'tensorboard>=2.4.1',
         'tensorflow-io>=0.32.0'
     ],


### PR DESCRIPTION
Added .bashrc parsing to a /tmp/.tensorboard file if the relevant env vars are specified in .bashrc instead of ~/.tensorboard.
Why? Because in some contexts like docker-stacks, the user may not have a guarantee that the .bashrc is sourced in the runtime session when the tensorboard proxy is clicked/launched. But at the same time, the user may prefer to use only a ~/.bashrc. With just one additional TF_LOG_DIR var, they can direct tensorboard to look for logs in that location, and use the same AWS s3 credentials as their other projects, without keeping duplicates in 2 files. Other libraries won't look for ~/.tensorboard. But it exists when you want to curate maybe a separate s3 bucket just for this.